### PR TITLE
Replace shade with openstacksdk

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 dateutils
-shade
+openstacksdk

--- a/sour.py
+++ b/sour.py
@@ -5,7 +5,7 @@ import argparse
 import csv
 import datetime
 import dateutil.relativedelta
-import shade
+import openstack
 import sys
 
 args = None
@@ -16,7 +16,7 @@ class Usage(Exception):
         self.msg = msg
 
 def get_cloud(cloudname):
-    cloud = shade.openstack_cloud(cloud=cloudname)
+    cloud = openstack.connect(cloud=cloudname)
     return cloud
 
 def get_projects(cloud):


### PR DESCRIPTION
[Quoting warning](https://docs.openstack.org/shade/latest/) from upstream:

> shade has been superceded by openstacksdk and no longer takes new
> features. The existing code will continue to be maintained indefinitely
> for bugfixes as necessary, but improvements will be deferred to
> openstacksdk. Please update your applications to use openstacksdk
> directly.

The conversion seems simple enough, but still, please review, and let me
know if you would like me to change anything before merging!